### PR TITLE
fix(security): Harden APIs — restrict CORS, remove hardcoded secrets, gate debug endpoints, add auth on critical routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 
 # Credenciales de PostgreSQL
 DB_USER=postgres
-DB_PASSWORD=tu_password
+DB_PASSWORD=your_secure_password_here
 DB_PORT=5432
 DB_NAME=ecosystems_db
 DB_HOST=db
@@ -12,3 +12,9 @@ DB_HOST=db
 # Configuración de RabbitMQ y MQTT (opcional)
 RABBITMQ_URL=amqp://guest:guest@rabbitmq/
 MQTT_BROKER=mqtt://mosquitto
+
+# CORS: comma-separated allowed origins
+CORS_ORIGINS=http://localhost:3000
+
+# Environment: set to 'development' to enable debug endpoints
+NODE_ENV=production

--- a/api/adaptador_lorawan.js
+++ b/api/adaptador_lorawan.js
@@ -4,7 +4,13 @@ const cors = require('cors');
 
 const app = express();
 app.use(express.json());
-app.use(cors());
+
+const ALLOWED_ORIGINS = (process.env.CORS_ORIGINS || 'http://localhost:3000').split(',');
+app.use(cors({
+    origin: ALLOWED_ORIGINS,
+    methods: ['GET', 'POST'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+}));
 
 const PORT = process.env.PORT || 8004;
 const RABBITMQ_URL = process.env.RABBITMQ_URL || "amqp://localhost";
@@ -133,7 +139,7 @@ app.post('/api/v1/lorawan/webhook', async (req, res) => {
 
     } catch (e) {
         console.error("[LoRaWAN Webhook] Error interno:", e.message);
-        return res.status(500).json({ error: `Error interno: ${e.message}` });
+        return res.status(500).json({ error: "Error interno del servidor" });
     }
 });
 

--- a/api/api_historicos.js
+++ b/api/api_historicos.js
@@ -4,14 +4,26 @@ const cors = require('cors');
 
 const app = express();
 app.use(express.json());
-app.use(cors());
 
 require('dotenv').config({ path: require('path').resolve(__dirname, '../.env') });
 
+const ALLOWED_ORIGINS = (process.env.CORS_ORIGINS || 'http://localhost:3000').split(',');
+app.use(cors({
+    origin: ALLOWED_ORIGINS,
+    methods: ['GET', 'POST'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-User-Role'],
+}));
+
 const PORT = process.env.PORT || 8002;
+
+if (!process.env.DB_PASSWORD) {
+    console.error('FATAL: DB_PASSWORD environment variable is required');
+    process.exit(1);
+}
+
 const DB_CONFIG = {
     user: process.env.DB_USER || 'postgres',
-    password: process.env.DB_PASSWORD || 'tu_password',
+    password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME || 'ecosystems_db',
     host: process.env.DB_HOST || '127.0.0.1',
     port: parseInt(process.env.DB_PORT || '5432')
@@ -156,7 +168,7 @@ app.get('/api/v1/analytics', async (req, res) => {
 
     } catch (e) {
         await logSystemError('CODIGO', 'Error en consulta de analíticas US-08', e.stack, nodeId);
-        res.status(500).json({ error: "INTERNAL_SERVER_ERROR", message: e.message });
+        res.status(500).json({ error: "INTERNAL_SERVER_ERROR", message: "Error al consultar analíticas." });
     }
 });
 
@@ -211,13 +223,13 @@ app.get('/api/reports/monthly', async (req, res) => {
 
     } catch (e) {
         await logSystemError('CODIGO', 'Error en generación de reporte mensual', e.stack);
-        res.status(500).json({ detail: e.message });
+        res.status(500).json({ detail: "Error interno del servidor" });
     }
 });
 
 app.get('/api/sensores/:id_nodo/historico', async (req, res) => {
     const { id_nodo } = req.params;
-    const dias = parseInt(req.query.dias) || 7;
+    const dias = Math.min(Math.max(parseInt(req.query.dias) || 7, 1), 90);
     
     try {
         const query = `
@@ -230,7 +242,7 @@ app.get('/api/sensores/:id_nodo/historico', async (req, res) => {
         res.json(rows);
     } catch (e) {
         await logSystemError('CODIGO', 'Error en consulta de históricos por nodo', e.stack, id_nodo);
-        res.status(500).json({ detail: e.message });
+        res.status(500).json({ detail: "Error interno del servidor" });
     }
 });
 
@@ -250,14 +262,16 @@ app.get('/api/estadisticas', async (req, res) => {
         res.json({ status: "success", data: rows });
     } catch (e) {
         await logSystemError('CODIGO', 'Error en consulta de estadísticas generales', e.stack);
-        res.status(500).json({ detail: e.message });
+        res.status(500).json({ detail: "Error interno del servidor" });
     }
 });
 
-// Endpoint de depuración para probar el capturador de errores (US-06)
-app.get('/api/debug/error', (req, res) => {
-    throw new Error("Fallo de prueba US-06: Excepción provocada");
-});
+// Debug endpoint: only available in development
+if (process.env.NODE_ENV === 'development') {
+    app.get('/api/debug/error', (req, res) => {
+        throw new Error("Fallo de prueba US-06: Excepción provocada");
+    });
+}
 
 // Cache en memoria para la última predicción válida (Escenario 2)
 const climateCache = {};
@@ -344,7 +358,7 @@ app.get('/api/v1/recommendations', async (req, res) => {
 
     } catch (e) {
         await logSystemError('CODIGO', 'Error en generación de recomendaciones', e.stack, sectorId);
-        res.status(500).json({ detail: e.message });
+        res.status(500).json({ detail: "Error interno del servidor" });
     }
 });
 

--- a/api/api_ingesta.js
+++ b/api/api_ingesta.js
@@ -4,7 +4,13 @@ const cors = require('cors');
 
 const app = express();
 app.use(express.json());
-app.use(cors());
+
+const ALLOWED_ORIGINS = (process.env.CORS_ORIGINS || 'http://localhost:3000').split(',');
+app.use(cors({
+    origin: ALLOWED_ORIGINS,
+    methods: ['GET', 'POST'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+}));
 
 const PORT = process.env.PORT || 8000;
 const RABBITMQ_URL = process.env.RABBITMQ_URL || "amqp://localhost";
@@ -91,7 +97,7 @@ app.post('/api/v1/readings', async (req, res) => {
         }
     } catch (e) {
         console.error(`[AUDIT] Error interno al procesar lectura: ${e.message}`);
-        return res.status(500).json({ error: `Error interno: ${e.message}` });
+        return res.status(500).json({ error: "Error interno del servidor" });
     }
 });
 
@@ -113,7 +119,7 @@ app.post('/api/mediciones', async (req, res) => {
             return res.status(503).json({ detail: "Servicio de colas no disponible" });
         }
     } catch (e) {
-        return res.status(500).json({ detail: `Error al publicar mensaje: ${e.message}` });
+        return res.status(500).json({ detail: "Error al publicar mensaje" });
     }
 });
 

--- a/api/api_perfiles.js
+++ b/api/api_perfiles.js
@@ -4,14 +4,26 @@ const cors = require('cors');
 
 const app = express();
 app.use(express.json());
-app.use(cors());
 
 require('dotenv').config({ path: require('path').resolve(__dirname, '../.env') });
 
+const ALLOWED_ORIGINS = (process.env.CORS_ORIGINS || 'http://localhost:3000').split(',');
+app.use(cors({
+    origin: ALLOWED_ORIGINS,
+    methods: ['GET', 'POST', 'PUT', 'DELETE'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+}));
+
 const PORT = process.env.PORT || 8003;
+
+if (!process.env.DB_PASSWORD) {
+    console.error('FATAL: DB_PASSWORD environment variable is required');
+    process.exit(1);
+}
+
 const DB_CONFIG = {
     user: process.env.DB_USER || 'postgres',
-    password: process.env.DB_PASSWORD || 'tu_password',
+    password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME || 'ecosystems_db',
     host: process.env.DB_HOST || '127.0.0.1',
     port: parseInt(process.env.DB_PORT || '5432')
@@ -23,7 +35,8 @@ app.get('/api/perfiles', async (req, res) => {
         const { rows } = await pool.query("SELECT * FROM perfil_cultivo ORDER BY id_perfil ASC");
         res.json(rows);
     } catch (e) {
-        res.status(500).json({ detail: e.message });
+        console.error('Error fetching profiles:', e.message);
+        res.status(500).json({ detail: "Error interno del servidor" });
     }
 });
 
@@ -79,7 +92,8 @@ app.post('/api/crop-profiles', async (req, res) => {
             maxHumidity 
         });
     } catch (e) {
-        res.status(500).json({ detail: e.message });
+        console.error('Error creating crop profile:', e.message);
+        res.status(500).json({ detail: "Error interno del servidor" });
     }
 });
 
@@ -117,7 +131,8 @@ app.put('/api/sectors/:sectorId/profile', async (req, res) => {
             message: `Perfil ${profileId} asignado al sector ${sectorId} exitosamente.` 
         });
     } catch (e) {
-        res.status(500).json({ detail: e.message });
+        console.error('Error assigning profile to sector:', e.message);
+        res.status(500).json({ detail: "Error interno del servidor" });
     }
 });
 
@@ -154,7 +169,8 @@ app.put('/api/irrigation/thresholds', async (req, res) => {
         
         res.json({ status: "success", data: rows[0] });
     } catch (e) {
-        res.status(500).json({ detail: e.message });
+        console.error('Error updating thresholds:', e.message);
+        res.status(500).json({ detail: "Error interno del servidor" });
     }
 });
 
@@ -168,7 +184,8 @@ app.delete('/api/perfiles/:id_perfil', async (req, res) => {
         
         res.json({ status: "success", message: `Perfil ${id_perfil} eliminado` });
     } catch (e) {
-        res.status(500).json({ detail: e.message });
+        console.error('Error deleting profile:', e.message);
+        res.status(500).json({ detail: "Error interno del servidor" });
     }
 });
 

--- a/api/controlador_valvulas.js
+++ b/api/controlador_valvulas.js
@@ -6,25 +6,45 @@ const cors = require('cors');
 
 const app = express();
 app.use(express.json());
-app.use(cors());
 
 require('dotenv').config({ path: require('path').resolve(__dirname, '../.env') });
+
+const ALLOWED_ORIGINS = (process.env.CORS_ORIGINS || 'http://localhost:3000').split(',');
+app.use(cors({
+    origin: ALLOWED_ORIGINS,
+    methods: ['GET', 'POST', 'PUT'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Operator-Token'],
+}));
 
 const PORT = process.env.PORT || 8001;
 const RABBITMQ_URL = process.env.RABBITMQ_URL || "amqp://localhost";
 const EXCHANGE_NAME = "telemetry_exchange";
 const QUEUE_NAME = "valvulas_queue";
-const SERIAL_PORT = process.env.SERIAL_PORT || "COM3"; // Ajustar al puerto donde conectes el Arduino
+const SERIAL_PORT = process.env.SERIAL_PORT || "COM3";
 const BAUD_RATE = 115200;
+
+if (!process.env.DB_PASSWORD) {
+    console.error('FATAL: DB_PASSWORD environment variable is required');
+    process.exit(1);
+}
 
 const DB_CONFIG = {
     user: process.env.DB_USER || 'postgres',
-    password: process.env.DB_PASSWORD || 'tu_password',
+    password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME || 'ecosystems_db',
     host: process.env.DB_HOST || '127.0.0.1',
     port: parseInt(process.env.DB_PORT || '5432')
 };
 const pool = new Pool(DB_CONFIG);
+
+// Authentication middleware for critical endpoints
+function requireOperatorAuth(req, res, next) {
+    const token = req.headers['authorization'];
+    if (!token) {
+        return res.status(401).json({ error: "UNAUTHORIZED", message: "Se requiere autenticación para esta operación." });
+    }
+    next();
+}
 
 let arduino;
 try {
@@ -274,7 +294,7 @@ async function accionarVálvula(id_valvula, accion, motivo, tiempo_inicio = Date
  * Escenario 1: Activación explícita de la parada global
  * Endpoint: POST /api/v1/system/emergency-stop/activate
  */
-app.post('/api/v1/system/emergency-stop/activate', async (req, res) => {
+app.post('/api/v1/system/emergency-stop/activate', requireOperatorAuth, async (req, res) => {
     const { reason, operatorId } = req.body;
 
     if (!reason || !operatorId) {
@@ -319,7 +339,7 @@ app.post('/api/v1/system/emergency-stop/activate', async (req, res) => {
     } catch (e) {
         await client.query('ROLLBACK');
         await logSystemError('BASE_DATOS', 'Fallo al activar emergencia', e.stack);
-        res.status(500).json({ error: "INTERNAL_SERVER_ERROR", message: e.message });
+        res.status(500).json({ error: "INTERNAL_SERVER_ERROR", message: "Error interno del servidor" });
     } finally {
         client.release();
     }
@@ -329,7 +349,7 @@ app.post('/api/v1/system/emergency-stop/activate', async (req, res) => {
  * Escenario 4: Desactivación segura de la alerta
  * Endpoint: POST /api/v1/system/emergency-stop/deactivate
  */
-app.post('/api/v1/system/emergency-stop/deactivate', async (req, res) => {
+app.post('/api/v1/system/emergency-stop/deactivate', requireOperatorAuth, async (req, res) => {
     const { operatorId } = req.body;
 
     if (!operatorId) {
@@ -365,7 +385,7 @@ app.post('/api/v1/system/emergency-stop/deactivate', async (req, res) => {
     } catch (e) {
         await client.query('ROLLBACK');
         await logSystemError('BASE_DATOS', 'Fallo al desactivar emergencia', e.stack);
-        res.status(500).json({ error: "INTERNAL_SERVER_ERROR", message: e.message });
+        res.status(500).json({ error: "INTERNAL_SERVER_ERROR", message: "Error interno del servidor" });
     } finally {
         client.release();
     }
@@ -395,7 +415,8 @@ app.get('/api/v1/valves/:id/status', async (req, res) => {
             overrideActive: valve.bloqueo_manual
         });
     } catch (e) {
-        res.status(500).json({ error: "INTERNAL_SERVER_ERROR", message: e.message });
+        console.error('Error getting valve status:', e.message);
+        res.status(500).json({ error: "INTERNAL_SERVER_ERROR", message: "Error interno del servidor" });
     }
 });
 
@@ -403,7 +424,7 @@ app.get('/api/v1/valves/:id/status', async (req, res) => {
  * Escenario 2: Ejecución de comando de control manual (Override con Prioridad)
  * Endpoint: POST /api/v1/valves/:id/override
  */
-app.post('/api/v1/valves/:id/override', async (req, res) => {
+app.post('/api/v1/valves/:id/override', requireOperatorAuth, async (req, res) => {
     const id_valvula = parseInt(req.params.id);
     const { action, operatorId, simulateTimeout } = req.body;
 
@@ -467,7 +488,7 @@ app.post('/api/v1/valves/:id/override', async (req, res) => {
 
     } catch (e) {
         await client.query('ROLLBACK');
-        res.status(500).json({ error: "INTERNAL_SERVER_ERROR", message: e.message });
+        res.status(500).json({ error: "INTERNAL_SERVER_ERROR", message: "Error interno del servidor" });
     } finally {
         client.release();
     }
@@ -496,7 +517,7 @@ app.post('/api/v1/valves/:id/auto', async (req, res) => {
 
         res.status(200).json({ status: "success", message: "Válvula devuelta a control automático." });
     } catch (e) {
-        res.status(500).json({ error: "INTERNAL_SERVER_ERROR", message: e.message });
+        res.status(500).json({ error: "INTERNAL_SERVER_ERROR", message: "Error interno del servidor" });
     }
 });
 
@@ -537,7 +558,8 @@ app.post('/api/v1/valve-logs', async (req, res) => {
             data: rows[0]
         });
     } catch (e) {
-        res.status(500).json({ detail: e.message });
+        console.error('Error creating valve log:', e.message);
+        res.status(500).json({ detail: "Error interno del servidor" });
     }
 });
 
@@ -569,7 +591,8 @@ app.get('/api/v1/valve-logs', async (req, res) => {
 
         res.status(200).json(rows);
     } catch (e) {
-        res.status(500).json({ detail: e.message });
+        console.error('Error fetching valve logs:', e.message);
+        res.status(500).json({ detail: "Error interno del servidor" });
     }
 });
 
@@ -589,7 +612,8 @@ app.get('/api/irrigation/events', async (req, res) => {
         const { rows } = await pool.query(query);
         res.json(rows);
     } catch (e) {
-        res.status(500).json({ detail: e.message });
+        console.error('Error fetching irrigation events:', e.message);
+        res.status(500).json({ detail: "Error interno del servidor" });
     }
 });
 
@@ -602,7 +626,8 @@ app.post('/api/valvulas/:id_valvula/accionar', async (req, res) => {
         const result = await accionarVálvula(id_valvula, accion, motivo);
         res.json(result);
     } catch (e) {
-        res.status(500).json({ detail: e.message });
+        console.error('Error legacy valve action:', e.message);
+        res.status(500).json({ detail: "Error interno del servidor" });
     }
 });
 

--- a/api/main.js
+++ b/api/main.js
@@ -3,22 +3,30 @@ const { Pool } = require('pg');
 const cors = require('cors');
 
 const app = express();
-// Middleware para parsear el body como JSON
 app.use(express.json());
-// Habilitar CORS para permitir peticiones desde el Frontend (React)
-app.use(cors());
 
 require('dotenv').config({ path: require('path').resolve(__dirname, '../.env') });
 
+const ALLOWED_ORIGINS = (process.env.CORS_ORIGINS || 'http://localhost:3000').split(',');
+app.use(cors({
+    origin: ALLOWED_ORIGINS,
+    methods: ['GET', 'POST'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+}));
+
 const PORT = process.env.PORT || 8000;
+
+if (!process.env.DB_PASSWORD) {
+    console.error('FATAL: DB_PASSWORD environment variable is required');
+    process.exit(1);
+}
 
 // =================================================================
 // 1. CONFIGURACIÓN DE BASE DE DATOS (Pool de conexiones)
 // =================================================================
-// Usamos un pool para manejar mejor las peticiones concurrentes (Requisito US-10)
 const pool = new Pool({
     user: process.env.DB_USER || 'postgres',
-    password: process.env.DB_PASSWORD || 'tu_password',
+    password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME || 'ecosystems_db',
     host: process.env.DB_HOST || 'localhost',
     port: parseInt(process.env.DB_PORT || '5432'),
@@ -70,7 +78,7 @@ app.post('/api/mediciones', async (req, res) => {
         return res.json({ status: "success", message: "Datos guardados correctamente" });
     } catch (error) {
         console.error("Error BD:", error);
-        return res.status(500).json({ detail: `Error al insertar en BD: ${error.message}` });
+        return res.status(500).json({ detail: "Error al insertar en BD" });
     }
 });
 
@@ -94,7 +102,7 @@ app.get('/api/estadisticas', async (req, res) => {
         res.json({ status: "success", data: rows });
     } catch (error) {
         console.error("Error BD Estadísticas:", error);
-        res.status(500).json({ detail: `Error al consultar históricos: ${error.message}` });
+        res.status(500).json({ detail: "Error al consultar históricos" });
     }
 });
 

--- a/api/swagger-server.js
+++ b/api/swagger-server.js
@@ -3,7 +3,13 @@ const cors = require('cors');
 
 const app = express();
 app.use(express.json());
-app.use(cors());
+
+const ALLOWED_ORIGINS = (process.env.CORS_ORIGINS || 'http://localhost:3000').split(',');
+app.use(cors({
+    origin: ALLOWED_ORIGINS,
+    methods: ['GET'],
+    allowedHeaders: ['Content-Type'],
+}));
 
 const PORT = process.env.PORT || 3000;
 

--- a/api/worker_historicos.js
+++ b/api/worker_historicos.js
@@ -10,9 +10,14 @@ const RABBITMQ_URL = process.env.RABBITMQ_URL || "amqp://localhost";
 const EXCHANGE_NAME = "telemetry_exchange";
 const QUEUE_NAME = "historicos_queue";
 
+if (!process.env.DB_PASSWORD) {
+    console.error('FATAL: DB_PASSWORD environment variable is required');
+    process.exit(1);
+}
+
 const DB_CONFIG = {
     user: process.env.DB_USER || 'postgres',
-    password: process.env.DB_PASSWORD || 'tu_password',
+    password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME || 'ecosystems_db',
     host: process.env.DB_HOST || '127.0.0.1',
     port: parseInt(process.env.DB_PORT || '5432')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       - DB_USER=${DB_USER}
       - DB_PASSWORD=${DB_PASSWORD}
       - DB_PORT=${DB_PORT}
+      - CORS_ORIGINS=http://localhost:3000,http://frontend:3000
+      - NODE_ENV=production
 
   frontend:
     build:


### PR DESCRIPTION
## Summary

Security hardening pass across all backend services addressing 6 critical vulnerability classes:

**1. Overly permissive CORS** — Every service used `app.use(cors())` (allow-all). Now restricted:
```js
const ALLOWED_ORIGINS = (process.env.CORS_ORIGINS || 'http://localhost:3000').split(',');
app.use(cors({ origin: ALLOWED_ORIGINS, methods: [...], allowedHeaders: [...] }));
```

**2. Hardcoded fallback password** — All DB configs fell back to `'tu_password'` when `DB_PASSWORD` was unset. Removed; services now fail-fast on missing credential:
```js
if (!process.env.DB_PASSWORD) { console.error('FATAL: ...'); process.exit(1); }
```

**3. Error information leakage** — ~20 endpoints returned raw `e.message` in 500 responses (exposes stack traces, DB schema). Replaced with generic `"Error interno del servidor"`.

**4. Exposed debug endpoint** — `/api/debug/error` unconditionally threw exceptions. Now gated behind `NODE_ENV === 'development'`.

**5. Missing authentication on critical endpoints** — Emergency-stop activate/deactivate and valve override had zero auth. Added `requireOperatorAuth` middleware (checks `Authorization` header presence).

**6. Unbounded query parameter** — `dias` param on `/api/sensores/:id/historico` accepted any integer (potential DoS). Clamped to `[1, 90]`.

Also: added `CORS_ORIGINS` and `NODE_ENV=production` to `.env.example` and `docker-compose.yml`.

Link to Devin session: https://app.devin.ai/sessions/92b72b69b64d4ac8a7762a7cade9a975
Requested by: @elterrordelauv